### PR TITLE
Delay overlay permission until user requests bubble

### DIFF
--- a/app/src/main/java/com/tbse/volumebubble/MainActivity.kt
+++ b/app/src/main/java/com/tbse/volumebubble/MainActivity.kt
@@ -35,6 +35,7 @@ import android.os.Bundle
 import android.provider.Settings
 import android.view.LayoutInflater
 import android.view.View
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import com.google.firebase.FirebaseApp
 import com.tbse.volumebubble.R.layout.*
@@ -63,10 +64,6 @@ class MainActivity : AppCompatActivity() {
         FirebaseApp.initializeApp(this)
 
         setContentView(activity_main)
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && !Settings.canDrawOverlays(this)) {
-            requestOverlayPermission()
-        }
 
     }
 
@@ -97,10 +94,21 @@ class MainActivity : AppCompatActivity() {
     private fun noPermissions() {
         activityMainBinding.needPerms.visibility = View.VISIBLE
         activityMainBinding.about.visibility = View.GONE
-        activityMainBinding.add.text = getString(R.string.request_permission)
+        activityMainBinding.add.text = getString(R.string.add_bubble)
         activityMainBinding.add.setOnClickListener {
-            requestOverlayPermission()
+            showPermissionDialog()
         }
+    }
+
+    private fun showPermissionDialog() {
+        AlertDialog.Builder(this)
+            .setTitle(R.string.overlay_permission_title)
+            .setMessage(R.string.overlay_permission_rationale)
+            .setPositiveButton(android.R.string.ok) { _, _ ->
+                requestOverlayPermission()
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .show()
     }
 
     @TargetApi(Build.VERSION_CODES.M)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,6 +33,8 @@
     <string name="this_app_requires_permission_to_draw_over_other_apps">This app requires permission to draw over other apps.</string>
     <string name="request_permission">Request Permission</string>
     <string name="add_bubble">Add Bubble</string>
+    <string name="overlay_permission_title">Permission Required</string>
+    <string name="overlay_permission_rationale">This app requires permission to draw over other apps in order to display the bubble.</string>
     <string name="volume_bubble">volume bubble</string>
     <string name="volume_bubble_trash_icon">Volume bubble trash icon</string>
 </resources>


### PR DESCRIPTION
## Summary
- show an explanation dialog before launching the overlay permission screen
- only launch permission screen after the user tries to add a bubble

## Testing
- `gradle assembleDebug` *(fails: local.properties missing)*

------
https://chatgpt.com/codex/tasks/task_e_68544ee82ab8832cbe49202b33fbafa5