### PR TITLE
Ensure bubble persists after activity restarts

### DIFF
--- a/app/src/main/java/com/tbse/volumebubble/MainActivity.kt
+++ b/app/src/main/java/com/tbse/volumebubble/MainActivity.kt
@@ -142,7 +142,9 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun initializeBubblesManager() {
-        bubblesManager = BubblesManager.Builder(this)
+        // Use the application context so the bubble doesn't disappear when the
+        // activity is recreated or closed
+        bubblesManager = BubblesManager.Builder(applicationContext)
             .setTrashLayout(bubble_trash_layout)
             .build()
         bubblesManager?.initialize()

--- a/bubbles/src/main/java/com/txusballesteros/bubbles/BubblesManager.java
+++ b/bubbles/src/main/java/com/txusballesteros/bubbles/BubblesManager.java
@@ -83,7 +83,10 @@ public class BubblesManager {
         private BubblesManager bubblesManager;
 
         public Builder(Context context) {
-            this.bubblesManager = getInstance(context);
+            // Use the application context so the service survives activity
+            // recreation and the bubble persists until explicitly removed
+            Context appContext = context.getApplicationContext();
+            this.bubblesManager = getInstance(appContext);
         }
 
         public Builder setTrashLayout(int trashLayoutResourceId) {


### PR DESCRIPTION
## Summary
- use application context when building `BubblesManager`
- initialize the service with application context so bubbles remain visible even after the activity is closed

## Testing
- `gradle test` *(fails: compileSdkVersion not specified)*

------
https://chatgpt.com/codex/tasks/task_e_685452bf75d4832c88bc87feef4a57bc