### PR TITLE
Use foreground service for bubble and modernize UI

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,6 +37,8 @@ android {
 dependencies {
     implementation project(':bubbles')
 //    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation 'androidx.core:core:1.12.0'
+    implementation 'com.google.android.material:material:1.12.0'
     implementation platform('com.google.firebase:firebase-bom:32.7.2')
     implementation 'com.google.firebase:firebase-analytics'
     implementation 'androidx.appcompat:appcompat:1.6.1'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,6 +26,8 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- Needed for foreground service that hosts the bubble overlay -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/tbse/volumebubble/MainActivity.kt
+++ b/app/src/main/java/com/tbse/volumebubble/MainActivity.kt
@@ -37,6 +37,7 @@ import android.view.LayoutInflater
 import android.view.View
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.firebase.FirebaseApp
 import com.tbse.volumebubble.R.layout.*
 import com.tbse.volumebubble.databinding.ActivityMainBinding
@@ -86,7 +87,7 @@ class MainActivity : AppCompatActivity() {
         activityMainBinding.add.text = getString(R.string.add_bubble)
         activityMainBinding.add.visibility = View.VISIBLE
         activityMainBinding.add.setOnClickListener { addNewBubble() }
-        activityMainBinding.about.setOnClickListener { startActivity(Intent(this, About::class.java)) }
+        activityMainBinding.about.setOnClickListener { showAboutDialog() }
         initializeBubblesManager()
     }
 
@@ -108,6 +109,15 @@ class MainActivity : AppCompatActivity() {
                 requestOverlayPermission()
             }
             .setNegativeButton(android.R.string.cancel, null)
+            .show()
+    }
+
+    private fun showAboutDialog() {
+        val view = layoutInflater.inflate(R.layout.content_about, null)
+        MaterialAlertDialogBuilder(this)
+            .setTitle(R.string.title_activity_about)
+            .setView(view)
+            .setPositiveButton(android.R.string.ok, null)
             .show()
     }
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -34,19 +34,19 @@
     android:paddingBottom="@dimen/activity_vertical_margin"
     tools:context="com.tbse.volumebubble.MainActivity">
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/need_perms"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/this_app_requires_permission_to_draw_over_other_apps" />
 
-    <Button
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/about"
         android:layout_width="match_parent"
         android:layout_height="50dp"
         android:text="@string/about_app" />
 
-    <Button
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/add"
         android:layout_width="match_parent"
         android:layout_height="50dp"

--- a/app/src/main/res/layout/content_about.xml
+++ b/app/src/main/res/layout/content_about.xml
@@ -7,7 +7,7 @@
     tools:context=".About"
     tools:showIn="@layout/activity_about">
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/tbse"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -15,7 +15,7 @@
         android:padding="20dp"
         android:text="@string/todd_b_smith_enterprises_llc_http_toddbsmith_com" />
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/iconmadeby"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,4 +37,5 @@
     <string name="overlay_permission_rationale">This app requires permission to draw over other apps in order to display the bubble.</string>
     <string name="volume_bubble">volume bubble</string>
     <string name="volume_bubble_trash_icon">Volume bubble trash icon</string>
+    <string name="bubble_service_running">Volume bubble service running</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -24,7 +24,7 @@
 -->
 <resources>
 
-    <style name="AppTheme" parent="Theme.AppCompat.Dialog" />
+    <style name="AppTheme" parent="Theme.Material3.DayNight.Dialog" />
 
     <style name="AppTheme.NoActionBar">
         <item name="windowActionBar">false</item>

--- a/bubbles/build.gradle
+++ b/bubbles/build.gradle
@@ -20,7 +20,10 @@ android {
     namespace 'com.txusballesteros.bubbles'
 }
 
-dependencies { implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version" }
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation 'androidx.core:core:1.12.0'
+}
 
 repositories {
     mavenCentral()

--- a/bubbles/src/main/java/com/txusballesteros/bubbles/BubblesManager.java
+++ b/bubbles/src/main/java/com/txusballesteros/bubbles/BubblesManager.java
@@ -29,6 +29,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.ServiceConnection;
 import android.os.IBinder;
+import android.os.Build;
 
 public class BubblesManager {
     private static BubblesManager INSTANCE;
@@ -68,7 +69,13 @@ public class BubblesManager {
     }
 
     public void initialize() {
-        context.bindService(new Intent(context, BubblesService.class),
+        Intent intent = new Intent(context, BubblesService.class);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            context.startForegroundService(intent);
+        } else {
+            context.startService(intent);
+        }
+        context.bindService(intent,
                 bubbleServiceConnection,
                 Context.BIND_AUTO_CREATE);
     }

--- a/bubbles/src/main/java/com/txusballesteros/bubbles/BubblesService.java
+++ b/bubbles/src/main/java/com/txusballesteros/bubbles/BubblesService.java
@@ -25,6 +25,9 @@
 package com.txusballesteros.bubbles;
 
 import android.app.Service;
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
 import android.content.Intent;
 import android.graphics.PixelFormat;
 import android.os.Binder;
@@ -36,7 +39,8 @@ import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.WindowManager;
-import android.widget.Toast;
+import androidx.core.app.NotificationCompat;
+import com.txusballesteros.bubbles.R;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -47,6 +51,23 @@ public class BubblesService extends Service {
     private BubbleTrashLayout bubblesTrash;
     private WindowManager windowManager;
     private BubblesLayoutCoordinator layoutCoordinator;
+
+    private static final String CHANNEL_ID = "bubble_service";
+    private static final int NOTIFICATION_ID = 42;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        createNotificationChannel();
+        String title = getApplicationInfo().loadLabel(getPackageManager()).toString();
+        Notification notification = new NotificationCompat.Builder(this, CHANNEL_ID)
+                .setContentTitle(title)
+                .setContentText(getString(R.string.bubble_service_running))
+                .setSmallIcon(getApplicationInfo().icon)
+                .setOngoing(true)
+                .build();
+        startForeground(NOTIFICATION_ID, notification);
+    }
 
     @Override
     public IBinder onBind(Intent intent) {
@@ -158,6 +179,19 @@ public class BubblesService extends Service {
     public class BubblesServiceBinder extends Binder {
         public BubblesService getService() {
             return BubblesService.this;
+        }
+    }
+
+    private void createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationChannel channel = new NotificationChannel(
+                    CHANNEL_ID,
+                    "Bubble Service",
+                    NotificationManager.IMPORTANCE_LOW);
+            NotificationManager manager = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+            if (manager != null) {
+                manager.createNotificationChannel(channel);
+            }
         }
     }
 }

--- a/bubbles/src/main/res/values/strings.xml
+++ b/bubbles/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="bubble_service_running">Bubble service running</string>
+</resources>


### PR DESCRIPTION
## Summary
- modernize the app theme and layouts with Material components
- add foreground service permission and UI strings
- start bubble service in the foreground
- show the About screen using a Material dialog
- keep bubbles alive by starting a foreground service

## Testing
- `gradle tasks --all`
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68741ab7e598832c8c64047cdd8982fe